### PR TITLE
Setup Convenience Defaults

### DIFF
--- a/lib/operational/form.rb
+++ b/lib/operational/form.rb
@@ -18,7 +18,7 @@ module Operational
       end
     end
 
-    def self.build(model: nil, model_persisted: nil, state: {}, prepopulate_method: :prepopulate)
+    def self.build(model: nil, model_persisted: nil, state: {}, build_method: :on_build)
       form = new
 
       if model
@@ -30,7 +30,7 @@ module Operational
 
       form.instance_variable_set(:@_operational_model_persisted, (model_persisted.nil? ? model&.persisted? || false : !!model_persisted))
       form.instance_variable_set(form.send(:_operational_state_variable), state.dup.freeze)
-      form.send(prepopulate_method, state) if form.respond_to?(prepopulate_method)
+      form.send(build_method, state) if form.respond_to?(build_method)
       form.changes_applied if form.respond_to?(:changes_applied)
       form
     end

--- a/lib/operational/operation/contract.rb
+++ b/lib/operational/operation/contract.rb
@@ -1,16 +1,16 @@
 module Operational
   class Operation
     module Contract
-      def self.Build(contract:, name: :contract, model_key: nil, model_persisted: nil, prepopulate_method: :prepopulate)
+      def self.Build(contract:, name: :contract, model_key: :model, model_persisted: nil, build_method: :on_build)
         lambda do |state|
-          model = model_key.present? ? state[model_key] : nil
-          raise InvalidContractModel if model_key.present? && model.nil?
+          model = state.key?(model_key) ? state[model_key] : nil
+          raise InvalidContractModel if state.key?(model_key) && model.nil?
 
           state[name] = contract.build(
             model: model,
             model_persisted: model_persisted,
             state: state,
-            prepopulate_method: prepopulate_method
+            build_method: build_method
           )
           true
         end
@@ -29,10 +29,10 @@ module Operational
         end
       end
 
-      def self.Sync(name: :contract, model_key: nil, sync_method: :on_sync)
+      def self.Sync(name: :contract, model_key: :model, sync_method: :on_sync)
         lambda do |state|
-          model = model_key.present? ? state[model_key] : nil
-          raise InvalidContractModel if model_key.present? && model.nil?
+          model = state.key?(model_key) ? state[model_key] : nil
+          raise InvalidContractModel if state.key?(model_key) && model.nil?
 
           state[name].sync(model: model, state: state, sync_method: sync_method)
         end

--- a/spec/operational/form_spec.rb
+++ b/spec/operational/form_spec.rb
@@ -120,32 +120,45 @@ RSpec.describe Operational::Form do
       end
     end
 
-    describe "prepopulate" do
+    describe "on_build" do
       let(:form_class) do
         Class.new(Operational::Form) do
           attribute :name, :string
 
-          def prepopulate(state)
+          def on_build(state)
             self.name = "prepopulated"
           end
         end
       end
 
-      it "calls prepopulate if defined" do
+      it "calls on_build if defined" do
         form = form_class.build
         expect(form.name).to eq "prepopulated"
       end
 
-      it "allows overriding the prepopulate method name" do
+      it "passes state to on_build" do
         form_class = Class.new(Operational::Form) do
           attribute :name, :string
 
-          def custom_prepopulate(state)
+          def on_build(state)
+            self.name = state[:default_name]
+          end
+        end
+
+        form = form_class.build(state: { default_name: "from state" })
+        expect(form.name).to eq "from state"
+      end
+
+      it "allows overriding the build method name" do
+        form_class = Class.new(Operational::Form) do
+          attribute :name, :string
+
+          def custom_build(state)
             self.name = "custom"
           end
         end
 
-        form = form_class.build(prepopulate_method: :custom_prepopulate)
+        form = form_class.build(build_method: :custom_build)
         expect(form.name).to eq "custom"
       end
     end
@@ -307,6 +320,19 @@ RSpec.describe Operational::Form do
 
         expect(state[:custom]).to eq true
       end
+    end
+  end
+
+  describe "#other_validators_have_passed?" do
+    it "returns true when there are no errors" do
+      form = form_class.build
+      expect(form.other_validators_have_passed?).to eq true
+    end
+
+    it "returns false when there are errors" do
+      form = form_class.build
+      form.validate(name: "")
+      expect(form.other_validators_have_passed?).to eq false
     end
   end
 

--- a/spec/operational/operation/contract_spec.rb
+++ b/spec/operational/operation/contract_spec.rb
@@ -224,21 +224,21 @@ RSpec.describe Operational::Operation::Contract do
           described_class::Sync().call(state.merge(model: "not a model"))
         }.to raise_error Operational::InvalidContractModel
       end
-    end
 
-    describe "sync_method" do
-      it "calls a custom sync_method during sync" do
-        form_class = Class.new(Operational::Form) do
-          attribute :name, :string
-          def custom_sync(state)
-            state[:model].email = "synced@test.com"
+      describe "sync_method" do
+        it "calls a custom sync_method during sync" do
+          form_class = Class.new(Operational::Form) do
+            attribute :name, :string
+            def custom_sync(state)
+              state[:model].email = "synced@test.com"
+            end
           end
+          state = { model: model, params: { name: "update" } }
+          described_class::Build(contract: form_class).call(state)
+          described_class::Validate().call(state)
+          described_class::Sync(sync_method: :custom_sync).call(state)
+          expect(model.email).to eq "synced@test.com"
         end
-        state = { model: model, params: { name: "update" } }
-        described_class::Build(contract: form_class).call(state)
-        described_class::Validate().call(state)
-        described_class::Sync(sync_method: :custom_sync).call(state)
-        expect(model.email).to eq "synced@test.com"
       end
     end
   end

--- a/spec/operational/operation/contract_spec.rb
+++ b/spec/operational/operation/contract_spec.rb
@@ -50,18 +50,60 @@ RSpec.describe Operational::Operation::Contract do
         model_class.new(name: "Test", email: "test@test.com")
       end
 
-      it "allows sending a model" do
-        expect(described_class::Build(contract: CreateForm, model_key: :model).call({ model: model })).to eq true
+      it "defaults to state[:model] when present" do
+        expect(described_class::Build(contract: CreateForm).call({ model: model })).to eq true
+      end
+
+      it "pre-populates form attributes from the model" do
+        state = { model: model }
+        described_class::Build(contract: CreateForm).call(state)
+        expect(state[:contract].name).to eq "Test"
+      end
+
+      it "builds without a model when state[:model] is absent" do
+        state = {}
+        described_class::Build(contract: CreateForm).call(state)
+        expect(state[:contract]).to be_a CreateForm
       end
 
       it "allows specifying the model key" do
         expect(described_class::Build(contract: CreateForm, model_key: :different_model).call({ different_model: model })).to eq true
       end
 
-      it "ensures the model quacks like an Active Model" do
+      it "raises when the model key is present in state but nil" do
         expect {
-          described_class::Build(contract: CreateForm, model_key: :invalid).call({ model: model })
+          described_class::Build(contract: CreateForm).call({ model: nil })
         }.to raise_error Operational::InvalidContractModel
+      end
+
+      it "raises when the model does not quack like an Active Model" do
+        expect {
+          described_class::Build(contract: CreateForm).call({ model: "not a model" })
+        }.to raise_error Operational::InvalidContractModel
+      end
+    end
+
+    describe "model_persisted" do
+      let(:model) { model_class.new(name: "Test") }
+
+      it "overrides persisted? on the form" do
+        state = { model: model }
+        described_class::Build(contract: CreateForm, model_persisted: true).call(state)
+        expect(state[:contract].persisted?).to eq true
+      end
+    end
+
+    describe "build_method" do
+      it "calls a custom build_method during build" do
+        form_class = Class.new(Operational::Form) do
+          attribute :name, :string
+          def custom_build(state)
+            self.name = "from custom build"
+          end
+        end
+        state = {}
+        described_class::Build(contract: form_class, build_method: :custom_build).call(state)
+        expect(state[:contract].name).to eq "from custom build"
       end
     end
   end
@@ -143,16 +185,60 @@ RSpec.describe Operational::Operation::Contract do
 
       let(:state) { { model: model, params: { name: "update", email: "update@test.com" }} }
 
-      it "allows sending a model" do
-        described_class::Build(contract: CreateForm, model_key: :model).call(state)
+      it "defaults to state[:model] when present" do
+        described_class::Build(contract: CreateForm).call(state)
 
-        expect(described_class::Sync(model_key: :model).call(state)).to eq true
+        expect(described_class::Sync().call(state)).to eq true
       end
 
-      it "ensures the model quacks like an Active Model" do
+      it "writes form attributes back to the model" do
+        described_class::Build(contract: CreateForm).call(state)
+        described_class::Validate().call(state)
+        described_class::Sync().call(state)
+        expect(model.name).to eq "update"
+      end
+
+      it "syncs without a model when state[:model] is absent" do
+        state = { params: { name: "update" } }
+        described_class::Build(contract: CreateForm).call(state)
+
+        expect(described_class::Sync().call(state)).to eq true
+      end
+
+      it "allows specifying the model key" do
+        state = { different_model: model, params: { name: "update" } }
+        described_class::Build(contract: CreateForm, model_key: :different_model).call(state)
+        described_class::Validate().call(state)
+        described_class::Sync(model_key: :different_model).call(state)
+        expect(model.name).to eq "update"
+      end
+
+      it "raises when the model key is present in state but nil" do
         expect {
-          described_class::Sync(model_key: :invalid).call(state)
+          described_class::Sync().call(state.merge(model: nil))
         }.to raise_error Operational::InvalidContractModel
+      end
+
+      it "raises when the model does not quack like an Active Model" do
+        expect {
+          described_class::Sync().call(state.merge(model: "not a model"))
+        }.to raise_error Operational::InvalidContractModel
+      end
+    end
+
+    describe "sync_method" do
+      it "calls a custom sync_method during sync" do
+        form_class = Class.new(Operational::Form) do
+          attribute :name, :string
+          def custom_sync(state)
+            state[:model].email = "synced@test.com"
+          end
+        end
+        state = { model: model, params: { name: "update" } }
+        described_class::Build(contract: form_class).call(state)
+        described_class::Validate().call(state)
+        described_class::Sync(sync_method: :custom_sync).call(state)
+        expect(model.email).to eq "synced@test.com"
       end
     end
   end


### PR DESCRIPTION
This sets the default `model_key` to `:model` which allieviates the need to specify `model_key` on all Contracts. Useful for simplifying single-model operations.

This also sets the Contract Build hook method from `prepopulate` to `on_build` which more closely matches the Sync, for consistency.